### PR TITLE
Fix getConsumerGroupDescript in kafkaNode.action

### DIFF
--- a/app/actions/kafkaNode.actions.ts
+++ b/app/actions/kafkaNode.actions.ts
@@ -2,8 +2,32 @@ import kafka from 'kafka-node';
 import * as _ from 'lodash';
 
 export const getConsumerGroupDescriptions = (clusterUrl, groudIds: string[], topic: string='', onComplete: (res:any) => void) => {
-  const client = new kafka.KafkaClient({kafkaHost: clusterUrl});
+  const [url, configString] = clusterUrl.split('?');
+
+  let options = {
+    kafkaHost: url,
+    connectRetryOptions: {
+      retries: 1
+    },
+    requestTimeout: 1000,
+    connectTimeout: 1000
+  };
+
+  if (configString) {
+    options.sasl = {};
+    configString.split('&').forEach(s => {
+      const [key, value] = s.split('=');
+      const [prefix, postfix] = key.split('.');
+      if (prefix === 'sasl') {
+        options.sasl[postfix] = value;
+      } else {
+        options[key] = value;
+      }
+    });
+  }
+  const client = new kafka.KafkaClient(options);
   const kafkaAdmin = new kafka.Admin(client);
+  onComplete([]);
 
   kafkaAdmin.describeGroups(groudIds, (err, descriptions) => {
     descriptions = Object.values(descriptions).map(gDescript => {


### PR DESCRIPTION
## Motivation
to resolve https://github.com/Kims-DeveloperGroup/franz-kafka/issues/20
by setting connection options
by calling onComplete first in case of error